### PR TITLE
Change stat system from dictionary to member variables

### DIFF
--- a/ModuleBerserk/Assets/Scenes/SampleScene.unity
+++ b/ModuleBerserk/Assets/Scenes/SampleScene.unity
@@ -1384,7 +1384,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c09ffb2ff461504e96636ddebf1a3f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HP: 100
+  maxHP: 100
   attackDamage: 20
   speed: 20
   moveRange: 5
@@ -2409,9 +2409,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b16858a3f80549f44b8e09a97126e530, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  HP: 100
+  maxHP: 100
   attackDamage: 20
-  speed: 10
 --- !u!1 &1218411720
 GameObject:
   m_ObjectHideFlags: 0
@@ -3007,7 +3006,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/ModuleBerserk/Assets/Scripts/Character/CharacterStat.cs
+++ b/ModuleBerserk/Assets/Scripts/Character/CharacterStat.cs
@@ -1,60 +1,47 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
-public struct Stat {
-    public float currentValue; // 현재값
-    public float minValue; //최솟값
-    public float maxValue; // 최댓값
+// 버프 또는 디버프가 가능한 유동적인 스탯을 관리하는 클래스.
+// 값이 바뀔 때마다 OnValueChange 이벤트로 알려줌.
+public class CharacterStat
+{
+    private float baseValue; // 버프와 최대치를 적용하지 않은 현재 값
+    private float additiveModifier = 0f; // 합연산 버프/디버프
+    private float multiplicativeModifier = 1f; // 곱연산 버프/디버프
 
-    public Stat(float maxValue) {
-        this.currentValue = maxValue;
-        this.minValue = 0;
-        this.maxValue = maxValue;
+    public float CurrentValue {get => Mathf.Clamp((baseValue + additiveModifier) * multiplicativeModifier, MinValue, MaxValue);} // 버프와 최대치를 적용한 최종 값
+    public float MinValue {get; private set;} //최솟값
+    public float MaxValue {get; private set;} // 최댓값
+
+    public UnityEvent<float> OnValueChange = new(); // 실질 수치가 변화할 때 호출되는 이벤트 (옵저버 패턴)
+
+    public CharacterStat(float baseValue, float minValue = float.NegativeInfinity, float maxValue = float.PositiveInfinity)
+    {
+        this.baseValue = baseValue;
+        MinValue = minValue;
+        MaxValue = maxValue;
     }
 
-    public void ApplyModifier(float modifier) {
-        this.currentValue += modifier;
-        this.currentValue = Math.Max(this.minValue, Math.Min(this.currentValue, this.maxValue)); //최댓값 및 최솟값을 초과하지 못하게함
-    }
-}
+    public void ModifyBaseValue(float modifier)
+    {
+        baseValue += modifier;
 
-public class CharacterStat : MonoBehaviour {
-    [SerializeField] private Dictionary<string, Stat> stats = new Dictionary<string, Stat>(); //Stat 저장하는 Dictionary
-    //근데 이거 Private 안잡고 걍 Public으로 가도 상관없을거 같은데
-    //일단 Private잡고 Get/Set씀
-
-    public void SetBaseStat(string statName, float maxValue){
-        if (!stats.ContainsKey(statName)) { //Stat이 없는 경우 새로 생성
-            stats.Add(statName, new Stat(maxValue));
-        }
-        else {
-            var existingStat = stats[statName];
-            existingStat.maxValue = maxValue;
-            existingStat.ApplyModifier(0); // Max, Min 범위때문에 한 번 실행
-            stats[statName] = existingStat;
-        }
+        OnValueChange.Invoke(CurrentValue);
     }
 
-    public void ModifyStat(string statName, float modifier){
-        if (stats.ContainsKey(statName)) {
-            // Stat 변경
-            var stat = stats[statName];
-            stat.ApplyModifier(modifier);
-            stats[statName] = stat;
-        }
-        else {
-            Debug.LogError(statName + " 엥? 이게 나오면 안되는데?");
-        }
+    public void ApplyAdditiveModifier(float modifier)
+    {
+        additiveModifier += modifier;
+
+        OnValueChange.Invoke(CurrentValue);
     }
 
-    public float GetModifiedStat(string statName) {
-        if (stats.ContainsKey(statName)) {
-            return stats[statName].currentValue;
-        }
-        else {
-            Debug.LogError(statName + "가 없다!");
-            return 0f;
-        }
+    public void ApplyMultiplicativeModifier(float modifier)
+    {
+        multiplicativeModifier *= modifier;
+
+        OnValueChange.Invoke(CurrentValue);
     }
 }

--- a/ModuleBerserk/Assets/Scripts/Character/Enemy/EnemyManager.cs
+++ b/ModuleBerserk/Assets/Scripts/Character/Enemy/EnemyManager.cs
@@ -1,25 +1,41 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UIElements.Experimental;
 
-public class EnemyManager : MonoBehaviour {
+public class EnemyManager : MonoBehaviour
+{
     private EnemyStat enemyStat;
 
-    private void Awake() {
+    private void Awake()
+    {
         enemyStat = GetComponent<EnemyStat>();
     }
 
-    private void OnTriggerEnter2D(Collider2D other) {
-        if (other.gameObject.layer == LayerMask.NameToLayer("Weapon")) { // Player 무기인지 확인
-            PlayerStat player = other.GetComponentInParent<PlayerStat>();
-            if (player != null) {
-                
-                enemyStat.ModifyStat("HP", -player.GetModifiedStat("Attack"));
-                Debug.Log("아야! 적 현재 체력: " + enemyStat.GetModifiedStat("HP")); //체력을 보여줄 방법을 찾지 못해 로그로 표현해봤습니다.
+    private void Start()
+    {
+        enemyStat.HP.OnValueChange.AddListener(HandleHPChange);
+    }
 
-                if (enemyStat.GetModifiedStat("HP") <= 0) { //적 사망
-                    Destroy(gameObject);
-                }
+    private void HandleHPChange(float hp)
+    {
+        //체력을 보여줄 방법을 찾지 못해 로그로 표현해봤습니다.
+        Debug.Log("아야! 적 현재 체력: " + hp);
+
+        if (hp <= 0) { //적 사망
+            Destroy(gameObject);
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        // Player 무기인지 확인
+        if (other.gameObject.layer == LayerMask.NameToLayer("Weapon"))
+        {
+            PlayerStat playerStat = other.GetComponentInParent<PlayerStat>();
+            if (playerStat != null)
+            {
+                enemyStat.HP.ModifyBaseValue(-playerStat.AttackDamage.CurrentValue);
             }
         }
     }

--- a/ModuleBerserk/Assets/Scripts/Character/Enemy/EnemyStat.cs
+++ b/ModuleBerserk/Assets/Scripts/Character/Enemy/EnemyStat.cs
@@ -2,9 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class EnemyStat : CharacterStat {
+public class EnemyStat : MonoBehaviour
+{
     [Header("HP")] //체력 변수
-    [SerializeField] private float HP;
+    [SerializeField] private float maxHP;
 
     [Header("Attack")] //공격력 변수
     [SerializeField] private float attackDamage;
@@ -15,11 +16,14 @@ public class EnemyStat : CharacterStat {
     [Header("MoveRange")] //이동반경
     [SerializeField] private float moveRange;
 
-    private void Start(){
-        //초기에 Stat Dictionary에 추가함
-        SetBaseStat("HP", HP);
-        SetBaseStat("Attack", attackDamage);
-        SetBaseStat("Speed", speed);
-        SetBaseStat("MoveRange", moveRange);
+    public CharacterStat HP;
+    public CharacterStat AttackDamage;
+    public CharacterStat Speed;
+
+    private void Awake()
+    {
+        HP = new CharacterStat(maxHP, 0f, maxHP);
+        AttackDamage = new CharacterStat(attackDamage, 0f);
+        Speed = new CharacterStat(speed, 0f);
     }
 }

--- a/ModuleBerserk/Assets/Scripts/Character/Player/PlayerManager.cs
+++ b/ModuleBerserk/Assets/Scripts/Character/Player/PlayerManager.cs
@@ -95,9 +95,22 @@ public class PlayerManager : MonoBehaviour
         FindComponentReferences();
         BindInputActions();
         
-
         groundContact = new(rb, boxCollider, groundLayerMask, contactDistanceThreshold);
         airControl = defaultAirControl;
+    }
+
+    private void Start()
+    {
+        playerStat.HP.OnValueChange.AddListener(HandleHPChange);
+    }
+
+    private void HandleHPChange(float hp)
+    {
+        Debug.Log($"아야! 내 현재 체력: {hp}");
+
+        // TODO:
+        // 1. 체력바 UI 업데이트
+        // 2. 사망 처리
     }
 
     private void FindComponentReferences()
@@ -443,10 +456,12 @@ public class PlayerManager : MonoBehaviour
             interactable.OnPlayerEnter();
             availableInteractables.Add(interactable);
         }
-        else if (other.gameObject.TryGetComponent(out EnemyStat enemy)) { // 일단 적이랑 충돌했을시 데미지 받는걸로 가정함
-            if (!isAttacking) { // 이것도 대충 처리해놈;
-                playerStat.ModifyStat("HP", -enemy.GetModifiedStat("Attack"));
-                Debug.Log("아야! 내 현재 체력: " + playerStat.GetModifiedStat("HP"));
+        // 일단 적이랑 충돌했을시 데미지 받는걸로 가정함
+        else if (other.gameObject.TryGetComponent(out EnemyStat enemy))
+        {
+            if (!isAttacking) // 이것도 대충 처리해놈;
+            {
+                playerStat.HP.ModifyBaseValue(-enemy.AttackDamage.CurrentValue);
             }
         }
     }

--- a/ModuleBerserk/Assets/Scripts/Character/Player/PlayerStat.cs
+++ b/ModuleBerserk/Assets/Scripts/Character/Player/PlayerStat.cs
@@ -2,20 +2,20 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class PlayerStat : CharacterStat {
+public class PlayerStat : MonoBehaviour
+{
     [Header("HP")] //체력 변수
-    [SerializeField] private float HP;
+    [SerializeField] private float maxHP;
 
     [Header("Attack")] //공격력 변수
     [SerializeField] private float attackDamage;
 
-    [Header("Speed")] //속도 변수
-    [SerializeField] private float speed;
+    public CharacterStat HP;
+    public CharacterStat AttackDamage;
 
-    private void Start(){
-        //초기에 Stat Dictionary에 추가함
-        SetBaseStat("HP", HP);
-        SetBaseStat("Attack", attackDamage);
-        SetBaseStat("Speed", speed);
+    private void Awake()
+    {
+        HP = new CharacterStat(maxHP, 0f, maxHP);
+        AttackDamage = new CharacterStat(attackDamage, 0f);
     }
 }


### PR DESCRIPTION
CharacterStat에서 dictionary를 그냥 public으로 만들어버리자는 주석을 보고 수정함:
1. 이제는 스탯의 이름을 string으로 가져오지 않고 명시적으로 스탯마다 CharacterStat HP처럼 멤버 변수로 보유함.

2. 스탯 값이 바뀔 때 체력바 UI를 조정하거나 사망 처리를 하는 등 작업이 필요하므로 옵저버 패턴을 적용함.
값 수정은 이전처럼 ModifyBaseValue() 함수로 하고, CharacterStat.OnValueChange에 자신의 callback을 등록하는 방식.

3. 무기 콜라이더에 isTrigger가 false여서 벽 근처에서 공격하면 플레이어가 밀려나는 현상이 있었음.
isTrigger 체크해서 수정함.

4. 간단한 형태의 버프/디버프 처리 구조를 만들었음.
합연산 버프와 곱연산 버프를 각각 float 변수로 보유하고 최종 스탯 (CurrentValue 프로퍼티) 계산 시 적용하는 방식.
최종 값과 버프 적용 전 기본 값을 구분하기 위해 BaseValue라는 멤버 변수를 추가함.

괜찮은 것 같으면 수락해주십셔